### PR TITLE
Added border and hatch options in qtldf

### DIFF
--- a/R/drawone.R
+++ b/R/drawone.R
@@ -526,7 +526,7 @@ drawone <-
             x2[1] + posmult * (qtlxpos + strwidth("M") + lgwpct / 3),
             qtldf$ei[ql],
             col = qtldf$col[ql],
-            density =hatch,
+            density = hatch[ql],
             border = qtldf$border[ql]
           )
           text(

--- a/R/drawone.R
+++ b/R/drawone.R
@@ -515,12 +515,16 @@ drawone <-
           )
           # make inner region 1/3 size of linkage group width
           # 1/3 is arbitrary, just looks good
+          add.hatch <- ifelse(all(is.logical(qtldf$border)), TRUE, FALSE)
+          if(is.null(qtldf$border)) 
+            qtldf$border <- qtldf$col
           rect(
             x2[1] + posmult * (qtlxpos + strwidth("M")),
             qtldf$si[ql],
             x2[1] + posmult * (qtlxpos + strwidth("M") + lgwpct / 3),
             qtldf$ei[ql],
             col = qtldf$col[ql],
+            density = ifelse(add.hatch,1,0), # add hatch if border is logical
             border = qtldf$border[ql]
           )
           text(

--- a/R/drawone.R
+++ b/R/drawone.R
@@ -456,6 +456,13 @@ drawone <-
       # determine x position of qtl
 
       if (nrow(qtldf) > 0) {
+        hatch <- 0
+        if(!is.null(qtldf$hatch))
+          hatch <- ifelse(qtldf$hatch, 30, 0) # if hatch is TRUE, set density to 30
+        write(hatch, stderr())
+        if(is.null(qtldf$border)) 
+          qtldf$border <- NA
+        write(qtldf$border, stderr())
         for (ql in 1:nrow(qtldf)) {
           # if there are labels on y axis where qtl needs to be drawn
           # first decide if QTL line (so to eo) or text label is longest
@@ -515,11 +522,6 @@ drawone <-
           )
           # make inner region 1/3 size of linkage group width
           # 1/3 is arbitrary, just looks good
-          hatch <- 0
-          if(!is.null(qtldf$hatch))
-            hatch <- ifelse(qtldf$hatch, 30, 0) # if hatch is TRUE, set density to 30
-          if(is.null(qtldf$border)) 
-            qtldf$border <- qtldf$col
           rect(
             x2[1] + posmult * (qtlxpos + strwidth("M")),
             qtldf$si[ql],

--- a/R/drawone.R
+++ b/R/drawone.R
@@ -521,7 +521,7 @@ drawone <-
             x2[1] + posmult * (qtlxpos + strwidth("M") + lgwpct / 3),
             qtldf$ei[ql],
             col = qtldf$col[ql],
-            border = qtldf$col[ql]
+            border = qtldf$border[ql]
           )
           text(
             x2[1] + posmult * (qtlxpos + strwidth("MM") + lgwpct / 3),

--- a/R/drawone.R
+++ b/R/drawone.R
@@ -458,11 +458,9 @@ drawone <-
       if (nrow(qtldf) > 0) {
         hatch <- 0
         if(!is.null(qtldf$hatch))
-          hatch <- ifelse(qtldf$hatch, 30, 0) # if hatch is TRUE, set density to 30
-        write(hatch, stderr())
+          hatch <- ifelse(qtldf$hatch, 30, NA) # if hatch is TRUE, set density to 30
         if(is.null(qtldf$border)) 
           qtldf$border <- NA
-        write(qtldf$border, stderr())
         for (ql in 1:nrow(qtldf)) {
           # if there are labels on y axis where qtl needs to be drawn
           # first decide if QTL line (so to eo) or text label is longest

--- a/R/drawone.R
+++ b/R/drawone.R
@@ -515,7 +515,9 @@ drawone <-
           )
           # make inner region 1/3 size of linkage group width
           # 1/3 is arbitrary, just looks good
-          add.hatch <- ifelse(all(is.logical(qtldf$border)), TRUE, FALSE)
+          hatch <- 0
+          if(!is.null(qtldf$hatch))
+            hatch <- ifelse(qtldf$hatch, 30, 0) # if hatch is TRUE, set density to 30
           if(is.null(qtldf$border)) 
             qtldf$border <- qtldf$col
           rect(
@@ -524,7 +526,7 @@ drawone <-
             x2[1] + posmult * (qtlxpos + strwidth("M") + lgwpct / 3),
             qtldf$ei[ql],
             col = qtldf$col[ql],
-            density = ifelse(add.hatch,1,0), # add hatch if border is logical
+            density =hatch,
             border = qtldf$border[ql]
           )
           text(

--- a/R/lmv.linkage.plot.R
+++ b/R/lmv.linkage.plot.R
@@ -186,6 +186,8 @@
 #'          \item ei End of inner interval. Numeric.
 #'          \item eo End of outer interval. Numeric.
 #'          \item col Color for QTL.
+#'          \item border Color of QTL rectangle border (optionnal)
+#'          \item hatch Hatch or not QTL rectangle (optionnal). Logical.
 #'        }
 #'
 #' @param qtlscanone Optional scanone data frame from package r/qtl.  If provided,


### PR DESCRIPTION
I added the possibility to add a border around QTL rectangle of a different color and to hatch the QTL rectangle instead. These possibilities correspond to two optionnal columns in qtldf.